### PR TITLE
Add "--freeze" flag

### DIFF
--- a/advice_animal/cli.py
+++ b/advice_animal/cli.py
@@ -91,6 +91,11 @@ case.  (Click's API prevents showing the actual live url here, but check --confi
     is_flag=True,
     help="When loading advice from a url, don't pull if some version already exists locally.",
 )
+@click.option(
+    "--freeze",
+    is_flag=True,
+    help="Assume skip-update on all further operations against this advice url (useful for building a docker image).",
+)
 # Filtering
 @click.option(
     "--confidence", default="unset", help="Filter advice to be at least this confident"
@@ -116,6 +121,7 @@ def main(
     advice_url: str,
     advice_dir: Optional[str],
     skip_update: bool,
+    freeze: bool,
     # Choice of advice
     confidence: str,
     preview: bool,
@@ -130,7 +136,7 @@ def main(
 ) -> None:
     vmodule_init(v, vmodule)
     if advice_dir is None:
-        advice_path = update_local_cache(advice_url, skip_update)
+        advice_path = update_local_cache(advice_url, skip_update, freeze)
     else:
         advice_path = Path(advice_dir)
 

--- a/advice_animal/update_checkout.py
+++ b/advice_animal/update_checkout.py
@@ -17,13 +17,17 @@ def get_local_cache_name(url: str) -> str:
     return f"{repo_name}-{url_hash[:8]}"
 
 
-def update_local_cache(url: str, skip_update: bool) -> Path:
+def update_local_cache(url: str, skip_update: bool, freeze: bool = False) -> Path:
     import appdirs
 
     cache_dir = Path(appdirs.user_cache_dir("advice-animal", "advice-animal"))
     local_checkout = cache_dir / get_local_cache_name(url)
+    freeze_name = local_checkout / ".git" / "freeze"
     if not local_checkout.exists():
         subprocess.check_output(["git", "clone", url, local_checkout])
     elif not skip_update:
-        subprocess.check_output(["git", "pull"], cwd=local_checkout)
+        if not freeze_name.exists():
+            subprocess.check_output(["git", "pull"], cwd=local_checkout)
+    if freeze:
+        freeze_name.touch()
     return local_checkout


### PR DESCRIPTION
This is intended to be used to bake a snapshot of the advice repo into a docker image, so that you don't need to pass --skip-update on every subsequent invocation in the image.