### PR TITLE
Change git town's ship strategy

### DIFF
--- a/.git-branches.toml
+++ b/.git-branches.toml
@@ -41,7 +41,7 @@ create-prototype-branches = false
 # - squash-merge: in your local repo, squash-merge the feature branch into its parent branch
 #
 # All options update proposals of child branches and remove the shipped branch locally and remotely.
-ship-strategy = "api"
+ship-strategy = "fast-forward"
 
 # Should "git town ship" delete the tracking branch?
 # You want to disable this if your code hosting platform


### PR DESCRIPTION
Docs at https://www.git-town.com/preferences/ship-strategy#fast-forward say this still can enforce code review if `main` is protected, and will definitely push the right commits.  I wasn't sure of either of those before.