### PR TITLE
Advice Descriptions parsed from BaseCheck subclass docstrings

### DIFF
--- a/advice_animal/api.py
+++ b/advice_animal/api.py
@@ -139,7 +139,6 @@ class BaseCheck:
     """
 
     confidence: FixConfidence = FixConfidence.UNSET
-    description: Optional[str] = None
     order: int = 50
 
     # Setting either of these requires extra user intent to run, within the confidence band.

--- a/advice_animal/api.py
+++ b/advice_animal/api.py
@@ -139,6 +139,7 @@ class BaseCheck:
     """
 
     confidence: FixConfidence = FixConfidence.UNSET
+    description: Optional[str] = None
     order: int = 50
 
     # Setting either of these requires extra user intent to run, within the confidence band.

--- a/advice_animal/cli.py
+++ b/advice_animal/cli.py
@@ -269,13 +269,9 @@ def show_list(ctx: click.Context) -> bool:
     for advice_name, check_cls in runner.order_check_classes(filter=everything):
         if check_cls.confidence.name != "UNSET":
             name = click.style(advice_name, fg=check_cls.confidence.name.lower())
-            description = click.style(check_cls.description, fg=check_cls.confidence.name.lower())
         else:
             name = click.style(advice_name, fg="green")
-            description = click.style(check_cls.description, fg="green")
         click.echo(f"* {name}{' - (preview)' if check_cls.preview else ''}")
-        if check_cls.description:
-            click.echo(f"    {description}")
     return True
 
 

--- a/advice_animal/cli.py
+++ b/advice_animal/cli.py
@@ -267,16 +267,16 @@ def show_list(ctx: click.Context) -> bool:
         name_filter=re.compile(".*"),
     )
     for advice_name, check_cls in runner.order_check_classes(filter=everything):
+        description = check_cls.__doc__.strip().split('\n')[0] if check_cls.__doc__ else None
         if check_cls.confidence.name != "UNSET":
             name = click.style(advice_name, fg=check_cls.confidence.name.lower())
-            description = click.style(check_cls.__doc__, fg=check_cls.confidence.name.lower()) if check_cls.__doc__ else None
+            description = click.style(description, fg=check_cls.confidence.name.lower()) if description else None
         else:
             name = click.style(advice_name, fg="green")
-            description = click.style(check_cls.__doc__, fg="green") if check_cls.__doc__ else None
+            description = click.style(description, fg="green") if description else None
         click.echo(f"* {name}{' - (preview)' if check_cls.preview else ''}")
         if description:
-            first_line = description.strip().split('\n')[0]  # Needs to be on a separate line to prevent backslash in f-string
-            click.echo(f"    {first_line}")
+            click.echo(f"   - {description}")
     return True
 
 

--- a/advice_animal/cli.py
+++ b/advice_animal/cli.py
@@ -269,9 +269,14 @@ def show_list(ctx: click.Context) -> bool:
     for advice_name, check_cls in runner.order_check_classes(filter=everything):
         if check_cls.confidence.name != "UNSET":
             name = click.style(advice_name, fg=check_cls.confidence.name.lower())
+            description = click.style(check_cls.__doc__, fg=check_cls.confidence.name.lower()) if check_cls.__doc__ else None
         else:
             name = click.style(advice_name, fg="green")
+            description = click.style(check_cls.__doc__, fg="green") if check_cls.__doc__ else None
         click.echo(f"* {name}{' - (preview)' if check_cls.preview else ''}")
+        if description:
+            first_line = description.strip().split('\n')[0]  # Needs to be on a separate line to prevent backslash in f-string
+            click.echo(f"    {first_line}")
     return True
 
 

--- a/advice_animal/cli.py
+++ b/advice_animal/cli.py
@@ -269,9 +269,13 @@ def show_list(ctx: click.Context) -> bool:
     for advice_name, check_cls in runner.order_check_classes(filter=everything):
         if check_cls.confidence.name != "UNSET":
             name = click.style(advice_name, fg=check_cls.confidence.name.lower())
+            description = click.style(check_cls.description, fg=check_cls.confidence.name.lower())
         else:
             name = click.style(advice_name, fg="green")
+            description = click.style(check_cls.description, fg="green")
         click.echo(f"* {name}{' - (preview)' if check_cls.preview else ''}")
+        if check_cls.description:
+            click.echo(f"    {description}")
     return True
 
 


### PR DESCRIPTION
When listing advice names in the bullet list, allow short descriptions of the advices to accompany them.